### PR TITLE
missing comma

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ setup(
                       "Markdown",
                       "six",
                       "Pygments",
-                      "peewee"]
-
+                      "peewee"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Environment :: Web Environment",


### PR DESCRIPTION
Setup.py is missing a comma which makes the dict illegal.  This is probably a problem upstream as well, but I haven't checked.
